### PR TITLE
Correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Or, you can do this:
 ```ruby
 result = UserSignup.run!(params)
 # Either returns the result of execute,
-# or raises ActiveInteraction::InteractionInvalid
+# or raises ActiveInteraction::InvalidInteractionError
 ```
 
 ## What can I pass to an interaction?


### PR DESCRIPTION
The error class listed in the README was incorrect.

Thanks for the great gem! This is exactly what I've been looking for.
