### PR TITLE
Fix #119; cache abstract filter's class

### DIFF
--- a/lib/active_interaction/filters/abstract_filter.rb
+++ b/lib/active_interaction/filters/abstract_filter.rb
@@ -8,11 +8,14 @@ module ActiveInteraction
   #
   # @private
   class AbstractFilter < Filter
-    private
-
     # @return [Class]
-    def klass
-      self.class.slug.to_s.camelize.constantize
+    attr_reader :klass
+    private :klass
+
+    def initialize(*)
+      super
+
+      @klass = self.class.slug.to_s.camelize.constantize
     end
   end
 end


### PR DESCRIPTION
Like #121, but merging into v1.1.0 instead of master.
