### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage Status][5]][6]
 [![Code Climate][7]][8]
 [![Dependency Status][9]][10]
+[![Inline docs][18]][19]
 
 At first it seemed alright. A little business logic in a controller
 or model wasn't going to hurt anything. Then one day you wake up
@@ -297,3 +298,5 @@ work done in [Mutations][17].
   [15]: https://github.com/tfausak
   [16]: https://github.com/orgsync
   [17]: https://github.com/cypriss/mutations
+  [18]: http://inch-pages.github.io/github/orgsync/active_interaction.png
+  [19]: http://inch-pages.github.io/github/orgsync/active_interaction "Inline docs"


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/orgsync/active_interaction.png)](http://inch-pages.github.io/github/orgsync/active_interaction) (which is great! seriously!)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for ActiveInteraction is http://inch-pages.github.io/github/orgsync/active_interaction/

Inch Pages is still in it's infancy, but already used by projects like [Virtus](https://github.com/solnic/virtus) and [libnotify](https://github.com/splattael/libnotify).

What do you think? :man:
