### PR TITLE
AbstractDateTimeFilter converts empty string to nil

### DIFF
--- a/lib/active_interaction/filters/abstract_date_time_filter.rb
+++ b/lib/active_interaction/filters/abstract_date_time_filter.rb
@@ -31,6 +31,8 @@ module ActiveInteraction
     private
 
     def convert(value)
+      return nil if value.blank?
+
       if format?
         klass.strptime(value, format)
       else

--- a/spec/active_interaction/filters/date_filter_spec.rb
+++ b/spec/active_interaction/filters/date_filter_spec.rb
@@ -32,6 +32,10 @@ describe ActiveInteraction::DateFilter, :filter do
         expect(result).to eql Date.parse(value)
       end
 
+      it 'returns nil if string is empty' do
+        expect(filter.cast('')).to be_nil
+      end
+
       context 'with format' do
         include_context 'with format'
 

--- a/spec/active_interaction/filters/date_time_filter_spec.rb
+++ b/spec/active_interaction/filters/date_time_filter_spec.rb
@@ -32,6 +32,10 @@ describe ActiveInteraction::DateTimeFilter, :filter do
         expect(result).to eql DateTime.parse(value)
       end
 
+      it 'returns nil if string is empty' do
+        expect(filter.cast('')).to be_nil
+      end
+
       context 'with format' do
         include_context 'with format'
 

--- a/spec/active_interaction/filters/time_filter_spec.rb
+++ b/spec/active_interaction/filters/time_filter_spec.rb
@@ -32,6 +32,10 @@ describe ActiveInteraction::TimeFilter, :filter do
         expect(result).to eql Time.parse(value)
       end
 
+      it 'returns nil if string is empty' do
+        expect(filter.cast('')).to be_nil
+      end
+
       context 'with format' do
         include_context 'with format'
 


### PR DESCRIPTION
Helps to avoid calling `Date.parse('')`

``` ruby
Date.parse('') # => ArgumentError: invalid date
```
