### PR TITLE
Camelize strings instead of classifying them

### DIFF
--- a/lib/active_interaction/filters/model_filter.rb
+++ b/lib/active_interaction/filters/model_filter.rb
@@ -39,7 +39,7 @@ module ActiveInteraction
     #
     # @raise [InvalidClassError]
     def klass
-      klass_name = options.fetch(:class, name).to_s.classify
+      klass_name = options.fetch(:class, name).to_s.camelize
       Object.const_get(klass_name)
     rescue NameError
       raise InvalidClassError, klass_name.inspect

--- a/spec/active_interaction/filters/model_filter_spec.rb
+++ b/spec/active_interaction/filters/model_filter_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 class Model; end
+class Things; end
 
 describe ActiveInteraction::ModelFilter, :filter do
   include_context 'filters'
@@ -112,6 +113,16 @@ describe ActiveInteraction::ModelFilter, :filter do
       before do
         options.merge!(class: Model.name)
       end
+
+      it 'returns the instance' do
+        expect(result).to eql value
+      end
+    end
+
+    context 'with a plural class' do
+      let(:value) { Things.new }
+
+      before { options[:class] = Things }
 
       it 'returns the instance' do
         expect(result).to eql value


### PR DESCRIPTION
Fixes #207.

Before the model filter would turn "things" into "Thing". Now it turns "things" into "Things".
