### PR TITLE
Fail early when given format for TimeZone

### DIFF
--- a/lib/active_interaction/filters/time_filter.rb
+++ b/lib/active_interaction/filters/time_filter.rb
@@ -26,6 +26,14 @@ module ActiveInteraction
     alias_method :_klass, :klass
     private :_klass
 
+    def initialize(name, options = {}, &block)
+      if options.key?(:format) && klass != Time
+        fail InvalidFilterError, 'format option unsupported with time zones'
+      end
+
+      super
+    end
+
     def cast(value)
       case value
       when Numeric

--- a/spec/active_interaction/filters/time_filter_spec.rb
+++ b/spec/active_interaction/filters/time_filter_spec.rb
@@ -14,6 +14,26 @@ describe ActiveInteraction::TimeFilter, :filter do
     end
   end
 
+  describe '#initialize' do
+    context 'with a format' do
+      before { options[:format] = '%T' }
+
+      context 'with a time zone' do
+        before do
+          time_zone = double
+          allow(Time).to receive(:zone).and_return(time_zone)
+
+          time_with_zone = double
+          allow(time_zone).to receive(:at).and_return(time_with_zone)
+        end
+
+        it 'raises an error' do
+          expect { filter }.to raise_error(ActiveInteraction::InvalidFilterError)
+        end
+      end
+    end
+  end
+
   describe '#cast' do
     let(:result) { filter.cast(value) }
 


### PR DESCRIPTION
Fixes #201.

`ActiveSupport::TimeZone` doesn't support `.strptime` like `Time` does. It's unlikely that it will ever be added, or that we could add it ourselves. So instead of waiting until run time to blow up, we'll fail right off the bat when you try to build a filter.

@AaronLasseigne can you look this over?
