### PR TITLE
Return results from invalid outcomes

### DIFF
--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -41,13 +41,8 @@ module ActiveInteraction
     #
     # @return (see #result)
     def result=(result)
-      if errors.empty?
-        @_interaction_result = result
-        @_interaction_valid = true
-      else
-        @_interaction_result = nil
-        @_interaction_valid = false
-      end
+      @_interaction_result = result
+      @_interaction_valid = errors.empty?
     end
 
     # @return [Boolean]

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -250,6 +250,7 @@ describe ActiveInteraction::Base do
             described_class.send(:define_method, :execute) do
               errors.add(:thing, 'error')
               errors.add_sym(:thing, :error, 'error')
+              true
             end
           end
 
@@ -263,8 +264,8 @@ describe ActiveInteraction::Base do
             expect(outcome).to be_invalid
           end
 
-          it 'sets the result to nil' do
-            expect(result).to be_nil
+          it 'sets the result' do
+            expect(result).to be true
           end
 
           it 'has errors' do

--- a/spec/active_interaction/concerns/runnable_spec.rb
+++ b/spec/active_interaction/concerns/runnable_spec.rb
@@ -101,9 +101,9 @@ describe ActiveInteraction::Runnable do
     context 'with an error' do
       include_context 'with an error'
 
-      it 'does not set the result' do
+      it 'sets the result' do
         instance.result = result
-        expect(instance.result).to be_nil
+        expect(instance.result).to eql result
       end
     end
 


### PR DESCRIPTION
Fixes #168.

``` irb
>> class Example < ActiveInteraction::Base
>>   boolean :b
>>   def execute
>>     errors.add(:b, 'falsey') unless b
>>     :something
>>   end
>> end
=> nil
>> outcome = Example.run(b: false)
=> #<Example:0x007fd16b5f8658 @b=false, @_interaction_errors=#<ActiveInteraction::Errors:0x007fd16b5f8310 @symbolic={}, @base=#<Example:0x007fd16b5f8658 ...>, @messages={:b=>["falsey"]}>, @_interaction_result=:something, @validation_context=nil, @_interaction_valid=false>
>> outcome.invalid?
=> true
>> outcome.result
=> :something
```

Needs review from @AaronLasseigne.

(Like #211, this should be merged into `v2.0.0`.)
