### PR TITLE
Increase Rubocop version since guard-rubocop requires 0.27.1.

### DIFF
--- a/active_interaction.gemspec
+++ b/active_interaction.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-rubocop', '~> 1.1'
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'rdoc', '~> 4.1'
-  spec.add_development_dependency 'rubocop', '0.26.0'
+  spec.add_development_dependency 'rubocop', '~> 0.27.1'
   spec.add_development_dependency 'yard', '~> 0.8'
   spec.add_development_dependency 'rspec', '3.1.0'
 


### PR DESCRIPTION
When I ran `bundle` on `v2.0.0` branch I got this error:

``` bash
admin@shein ~/projects/active_interaction (v2.0.0=) $ bundle
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
You have requested:
  rubocop = 0.26.0

The bundle currently has rubocop locked at 0.27.1.
Try running `bundle update rubocop`
```

This pull fixes it.
