### PR TITLE
Updated decimal filter to new ruby 2.6+ BigDecimal initialization format

### DIFF
--- a/lib/active_interaction/filters/decimal_filter.rb
+++ b/lib/active_interaction/filters/decimal_filter.rb
@@ -25,7 +25,7 @@ module ActiveInteraction
     def cast(value, _interaction)
       case value
       when Numeric
-        BigDecimal.new(value, digits)
+        BigDecimal(value, digits)
       when String
         decimal_from_string(value)
       else
@@ -47,7 +47,7 @@ module ActiveInteraction
     # @raise [InvalidValueError] if given value can not be converted
     def decimal_from_string(value)
       Float(value)
-      BigDecimal.new(value, digits)
+      BigDecimal(value, digits)
     rescue ArgumentError
       raise InvalidValueError, "Given value: #{value.inspect}"
     end


### PR DESCRIPTION
Ruby 2.6 throws a deprecation warning using `BigDecimal.new` instead of `BigDecimal()`.