### PR TITLE
Fix nested errors on arrays #466

### DIFF
--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -106,7 +106,7 @@ module ActiveInteraction
     private
 
     def attribute?(attribute)
-      @base.respond_to?(attribute)
+      @base.respond_to?(attribute.to_s.gsub(/\[(\d)+\]\z/, ''))
     end
 
     def detailed_error?(detail)


### PR DESCRIPTION
Fixes nested attribute errors (see #466 ), if the name is corresponding.

Reason why it was not working is, that the array is not directly addressed via the attribute name:

```ruby
    def attribute?(attribute)
      @base.respond_to?(attribute.to_s.gsub(/\[(\d)+\]\z/, ""))
    end

attribute
=> :"data[1]" # even though the attribute data is existing
```

My fix corrects this behaviour and test are running fine.

I didn't create so many PR in my life until now, so please feel free to correct me :)