### PR TITLE
Add Note in Readme about Interface not requiring methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,25 @@ InterfaceInteraction.run!(serializer: JSON)
 # => "{\"is_json\":true}"
 ```
 
+NOTE: The `methods` option is optional.
+
+```rb
+class InterfaceInteraction < ActiveInteraction::Base
+  interface :anything
+
+  def execute
+    anything.class
+  end
+end
+
+require 'json'
+
+InterfaceInteraction.run!(anything: Hash.new)
+# => Hash
+InterfaceInteraction.run!
+# => NilClass
+```
+
 ### Object
 
 Object filters allow you to require an instance of a particular class. It
@@ -668,7 +687,7 @@ sensible (e.g. `base: 10`).
 class IntegerInteraction < ActiveInteraction::Base
   integer :limit1, base: 10
   integer :limit2
-  
+
   def execute
     [limit1, limit2]
   end


### PR DESCRIPTION
The source code for the Interface Filter has an example where you don't have to supply any methods to it if you want to allow _anything_ in your interaction. This PR adds a similar example to the Readme to keep it consistent.