### PR TITLE
Pass instance of the interaction to InvalidInteractionError class

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,25 @@ InterfaceInteraction.run!(serializer: JSON)
 # => "{\"is_json\":true}"
 ```
 
+NOTE: The `methods` option is optional.
+
+```rb
+class InterfaceInteraction < ActiveInteraction::Base
+  interface :anything
+
+  def execute
+    anything.class
+  end
+end
+
+require 'json'
+
+InterfaceInteraction.run!(anything: Hash.new)
+# => Hash
+InterfaceInteraction.run!
+# => NilClass
+```
+
 ### Object
 
 Object filters allow you to require an instance of a particular class. It
@@ -668,7 +687,7 @@ sensible (e.g. `base: 10`).
 class IntegerInteraction < ActiveInteraction::Base
   integer :limit1, base: 10
   integer :limit2
-  
+
   def execute
     [limit1, limit2]
   end

--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -98,7 +98,7 @@ module ActiveInteraction
       run
 
       unless valid?
-        raise InvalidInteractionError, errors.full_messages.join(', ')
+        raise InvalidInteractionError.new self
       end
 
       result

--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -98,7 +98,7 @@ module ActiveInteraction
       run
 
       unless valid?
-        raise InvalidInteractionError.new self
+        raise InvalidInteractionError, self
       end
 
       result

--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -97,11 +97,9 @@ module ActiveInteraction
     def run!
       run
 
-      unless valid?
-        raise InvalidInteractionError, self
-      end
+      return result if valid?
 
-      result
+      raise InvalidInteractionError, self
     end
 
     #

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -31,7 +31,15 @@ module ActiveInteraction
   # Raised if an interaction is invalid.
   #
   # @return [Class]
-  InvalidInteractionError = Class.new(Error)
+  class InvalidInteractionError < Error
+    attr_reader :interaction
+
+    def initialize(interaction)
+      @interaction = interaction
+
+      super(interaction.errors.full_messages.join(', '))
+    end
+  end
 
   # Raised if a user-supplied value is invalid.
   #

--- a/spec/active_interaction/concerns/runnable_spec.rb
+++ b/spec/active_interaction/concerns/runnable_spec.rb
@@ -369,6 +369,14 @@ describe ActiveInteraction::Runnable do
             result
           end.to raise_error ActiveInteraction::InvalidInteractionError
         end
+
+        it 'adds interaction instance to this error' do
+          expect do
+            result
+          end.to raise_error do |error|
+            expect(error.interaction).to be_a klass
+          end
+        end
       end
     end
   end

--- a/spec/active_interaction/concerns/runnable_spec.rb
+++ b/spec/active_interaction/concerns/runnable_spec.rb
@@ -371,9 +371,7 @@ describe ActiveInteraction::Runnable do
         end
 
         it 'adds interaction instance to this error' do
-          expect do
-            result
-          end.to raise_error do |error|
+          expect { result }.to raise_error do |error|
             expect(error.interaction).to be_a klass
           end
         end


### PR DESCRIPTION
Allows an `ActiveInteraction::InvalidInteractionError` to behave in a similar way as `ActiveRecord::RecordInvalid` which exposes the failed `#record`.

`ActiveInteraction::InvalidInteractionError` exposes `#interaction` attribute which includes failing interaction. This feature allows for better inspection of why interaction failed and therefore makes feedback to consumers of interaction errors more flexible.

Take for example a Rails controller action which might need to be rescued and whose error details need to be passed to the frontend.

```ruby
class FooController < ApplicationController
  rescue_from ActiveInteraction::InvalidInteractionError do |exception|
    render json: { errors: exception.interaction.errors.details }, status: :unprocessable_entity
  end

  def update
    result = Foos::Update.run! permitted_params

    render json: result, serializer: FooSerializer, status: :updated
  end
end
```