### PR TITLE
report exact location where first error added

### DIFF
--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -101,7 +101,7 @@ module ActiveInteraction
 
       e = InvalidInteractionError.new(errors.full_messages.join(', '))
       e.interaction = self
-      e.set_backtrace(errors.backtrace) if errors.backtrace
+      e.set_backtrace(errors.backtrace) if errors.respond_to?(:backtrace) && errors.backtrace
       raise e
     end
 

--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -101,6 +101,7 @@ module ActiveInteraction
 
       e = InvalidInteractionError.new(errors.full_messages.join(', '))
       e.interaction = self
+      e.set_backtrace(errors.backtrace) if errors.backtrace
       raise e
     end
 

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -92,12 +92,16 @@ module ActiveInteraction
 
   # An extension that provides the ability to merge other errors into itself.
   class Errors < ActiveModel::Errors
+    attr_reader :backtrace
+
     # Merge other errors into this one.
     #
     # @param other [Errors]
     #
     # @return [Errors]
     def merge!(other)
+      @backtrace ||= other.backtrace if other.respond_to?(:backtrace)
+
       if other.respond_to?(:details)
         merge_details!(other)
       else
@@ -105,6 +109,14 @@ module ActiveInteraction
       end
 
       self
+    end
+
+    # Add a new error.
+    # @see ActiveModel::Errors#add
+    # @return [Array]
+    def add(*)
+      @backtrace ||= caller
+      super
     end
 
     private

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -24,6 +24,12 @@ InterruptInteraction = Class.new(TestInteraction) do
     class: Object,
     default: nil
 
+  # NOTE: the relative position between this method
+  #   and the compose line should be preserved.
+  def self.composition_location
+    "#{__FILE__}:#{__LINE__ + 4}:in `execute'"
+  end
+
   def execute
     compose(AddInteraction, x: x, y: z)
   end
@@ -370,6 +376,15 @@ describe ActiveInteraction::Base do
       it 'has the correct errors' do
         expect(outcome.errors.details)
           .to eql(x: [{ error: :missing }], base: [{ error: 'Y is required' }])
+      end
+
+      it 'has the correct backtrace' do
+        begin
+          described_class.run!(inputs)
+        rescue ActiveInteraction::InvalidInteractionError => e
+          expect(e.backtrace)
+            .to include(InterruptInteraction.composition_location)
+        end
       end
     end
   end


### PR DESCRIPTION
address #479

If we have a deeply composed interaction is very hard to tell where does the error exactly happened because the backtrace info is already lost when raising error from the top-level interaction.

This PR adds an `attr_reader` to `ActiveInteraction::Errors` to let it save the backtrace.

1. When the first error was added to the errors, the backtrace will be saved.
2. When the up-level errors merge other errors and its backtrace is not set, it will use the backtrace of the merged one. This way we ensure the exact error location can be reported all the way up.