### PR TITLE
Error description is nil

### DIFF
--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -116,7 +116,7 @@ module ActiveInteraction
     end
 
     def detailed_error?(detail)
-      detail[:error].is_a?(Symbol)
+      !detail.nil? && detail[:error].is_a?(Symbol)
     end
 
     def merge_messages!(other)

--- a/spec/active_interaction/errors_spec.rb
+++ b/spec/active_interaction/errors_spec.rb
@@ -79,6 +79,17 @@ describe ActiveInteraction::Errors do
         end
       end
 
+      context 'that is nil' do
+        it 'returns empty' do
+          no_details_error = OpenStruct.new(
+            messages: { attribute: ['is invalid'] },
+            details: { attribute: [nil] }
+          )
+          errors.merge!(no_details_error)
+          expect(errors.details[:attribute]).to eql [{ error: 'is invalid' }]
+        end
+      end
+
       context 'that is a symbol on base' do
         before do
           other.add(:base)


### PR DESCRIPTION
I found this edge case while working with the gem.

```ruby 
Failure/Error: errors.merge!(user.errors) unless user.save
     
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # /Users/alexandremondainicalvao/.rvm/gems/ruby-2.6.6/gems/active_interaction-3.8.1/lib/active_interaction/errors.rb:117:in `detailed_error?'
     # /Users/alexandremondainicalvao/.rvm/gems/ruby-2.6.6/gems/active_interaction-3.8.1/lib/active_interaction/errors.rb:140:in `block (2 levels) in merge_details!'
     # /Users/alexandremondainicalvao/.rvm/gems/ruby-2.6.6/gems/active_interaction-3.8.1/lib/active_interaction/errors.rb:138:in `zip'
     # /Users/alexandremondainicalvao/.rvm/gems/ruby-2.6.6/gems/active_interaction-3.8.1/lib/active_interaction/errors.rb:138:in `block in merge_details!'
     # /Users/alexandremondainicalvao/.rvm/gems/ruby-2.6.6/gems/active_interaction-3.8.1/lib/active_interaction/errors.rb:137:in `each'
     # /Users/alexandremondainicalvao/.rvm/gems/ruby-2.6.6/gems/active_interaction-3.8.1/lib/active_interaction/errors.rb:137:in `merge_details!'
     # /Users/alexandremondainicalvao/.rvm/gems/ruby-2.6.6/gems/active_interaction-3.8.1/lib/active_interaction/errors.rb:102:in `merge!'

```