### PR TITLE
allow hash inputs to take ActionController::Parameters

### DIFF
--- a/lib/active_interaction.rb
+++ b/lib/active_interaction.rb
@@ -23,6 +23,7 @@ require 'active_interaction/concerns/runnable'
 
 require 'active_interaction/grouped_input'
 
+require 'active_interaction/modules/action_params_compatibility'
 require 'active_interaction/modules/input_processor'
 require 'active_interaction/modules/validation'
 

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -280,13 +280,11 @@ module ActiveInteraction
     # Rails >= 5, parameters are not a subclass of hash but calling
     # `#to_unsafe_h` returns the entire hash.
     def normalize_inputs!(inputs)
+      inputs = ActionParamsCompatibility.cast_to_hash(inputs)
       return inputs if inputs.is_a?(Hash)
 
-      parameters = 'ActionController::Parameters'
-      klass = parameters.safe_constantize
-      return inputs.to_unsafe_h if klass && inputs.is_a?(klass)
-
-      raise ArgumentError, "inputs must be a hash or #{parameters}"
+      raise ArgumentError, 'inputs must be a hash or ' +
+        ActionParamsCompatibility.action_params_klass.to_s
     end
 
     # @param inputs [Hash{Symbol => Object}]

--- a/lib/active_interaction/filters/hash_filter.rb
+++ b/lib/active_interaction/filters/hash_filter.rb
@@ -28,7 +28,7 @@ module ActiveInteraction
 
     # rubocop:disable Metrics/MethodLength
     def cast(value, context)
-      value = normalize_inputs(value)
+      value = ActionParamsCompatibility.cast_to_hash(value)
       case value
       when Hash
         value = value.with_indifferent_access
@@ -73,20 +73,6 @@ module ActiveInteraction
     # @return [Boolean]
     def strip?
       options.fetch(:strip, true)
-    end
-
-    # We want to allow both `Hash` objects and `ActionController::Parameters`
-    # objects. In Rails < 5, parameters are a subclass of hash and calling
-    # `#symbolize_keys` returns the entire hash, not just permitted values. In
-    # Rails >= 5, parameters are not a subclass of hash but calling
-    # `#to_unsafe_h` returns the entire hash.
-    def normalize_inputs(inputs)
-      klass = 'ActionController::Parameters'.safe_constantize
-      if klass && inputs.is_a?(klass)
-        inputs.to_unsafe_h
-      else
-        inputs
-      end
     end
   end
 end

--- a/lib/active_interaction/modules/action_params_compatibility.rb
+++ b/lib/active_interaction/modules/action_params_compatibility.rb
@@ -14,7 +14,11 @@ module ActiveInteraction
       # `#to_unsafe_h` returns the entire hash.
       def cast_to_hash(params)
         return params if params.is_a? Hash
-        return params.to_unsafe_h if action_params_klass && params.is_a?(action_params_klass)
+
+        if action_params_klass && params.is_a?(action_params_klass)
+          return params.to_unsafe_h
+        end
+
         params
       end
 

--- a/lib/active_interaction/modules/action_params_compatibility.rb
+++ b/lib/active_interaction/modules/action_params_compatibility.rb
@@ -1,0 +1,28 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+module ActiveInteraction
+  # Convert ActionController::Params to hash
+  #
+  # @private
+  module ActionParamsCompatibility
+    class << self
+      # We want to allow both `Hash` objects and `ActionController::Parameters`
+      # objects. In Rails < 5, parameters are a subclass of hash and calling
+      # `#symbolize_keys` returns the entire hash, not just permitted values. In
+      # Rails >= 5, parameters are not a subclass of hash but calling
+      # `#to_unsafe_h` returns the entire hash.
+      def cast_to_hash(params)
+        if action_params_klass && params.is_a?(action_params_klass)
+          params.to_unsafe_h
+        else
+          params
+        end
+      end
+
+      def action_params_klass
+        @action_params_klass ||= 'ActionController::Parameters'.safe_constantize
+      end
+    end
+  end
+end

--- a/lib/active_interaction/modules/action_params_compatibility.rb
+++ b/lib/active_interaction/modules/action_params_compatibility.rb
@@ -13,11 +13,9 @@ module ActiveInteraction
       # Rails >= 5, parameters are not a subclass of hash but calling
       # `#to_unsafe_h` returns the entire hash.
       def cast_to_hash(params)
-        if action_params_klass && params.is_a?(action_params_klass)
-          params.to_unsafe_h
-        else
-          params
-        end
+        return params if params.is_a? Hash
+        return params.to_unsafe_h if action_params_klass && params.is_a?(action_params_klass)
+        params
       end
 
       def action_params_klass

--- a/spec/active_interaction/filters/hash_filter_spec.rb
+++ b/spec/active_interaction/filters/hash_filter_spec.rb
@@ -76,6 +76,16 @@ describe ActiveInteraction::HashFilter, :filter do
       end
     end
 
+    context 'with an ActionController::Parameters' do
+      require 'action_controller'
+
+      let(:value) { ActionController::Parameters.new }
+
+      it 'converts to a hash' do
+        expect(result).to eql({})
+      end
+    end
+
     context 'with :strip false' do
       let(:options) { { strip: false } }
 


### PR DESCRIPTION
Convert `ActionController::Parameters` to `hash` for hash inputs, the same way ActiveInteraction already converts ActionController::Parameters for overall inputs.

Previously, if `params` is an ActionController::Params and `h` is a hash input, then `Interaction.run(params)` would work, but `Interaction.run(h: params)` would raise an InvalidValueError.

This PR makes the latter case "just work".