### PR TITLE
Add support Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
   - rvm: 2.7
 
   # These test specific versions of ActiveModel that we support.
+    # Latest MRI, ActiveModel 6.1, RSpec only
+  - env: RAKE_TASK=spec
+    gemfile: gemfiles/activemodel-6.1.rb
+    rvm: 2.7
   # Latest MRI, ActiveModel 6.0, RSpec only
   - env: RAKE_TASK=spec
     gemfile: gemfiles/activemodel-6.0.rb

--- a/gemfiles/activemodel-6.1.rb
+++ b/gemfiles/activemodel-6.1.rb
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activemodel', '~> 6.1.0'
+gem 'activerecord', '~> 6.1.0'
+unless defined?(JRUBY_VERSION) # rubocop:disable Style/IfUnlessModifier
+  gem 'sqlite3', '~> 1.4.1'
+end

--- a/lib/active_interaction/backports.rb
+++ b/lib/active_interaction/backports.rb
@@ -3,57 +3,59 @@
 
 require 'active_support/core_ext'
 
-module ActiveInteraction
-  class Errors # rubocop:disable Style/Documentation
-    # Required for Rails < 5.
-    #
-    # Extracted from active_model-errors_details 1.2.0. Modified to add support
-    # for ActiveModel 3.2.0.
-    module Details
-      extend ActiveSupport::Concern
+if ActiveModel.version < Gem::Version.new('5')
+  module ActiveInteraction
+    class Errors # rubocop:disable Style/Documentation
+      # Required for Rails < 5.
+      #
+      # Extracted from active_model-errors_details 1.2.0. Modified to add
+      # support for ActiveModel 3.2.0.
+      module Details
+        extend ActiveSupport::Concern
 
-      CALLBACKS_OPTIONS = ::ActiveModel::Errors::CALLBACKS_OPTIONS
-      private_constant :CALLBACKS_OPTIONS
-      MESSAGE_OPTIONS = [:message].freeze
-      private_constant :MESSAGE_OPTIONS
+        CALLBACKS_OPTIONS = ::ActiveModel::Errors::CALLBACKS_OPTIONS
+        private_constant :CALLBACKS_OPTIONS
+        MESSAGE_OPTIONS = [:message].freeze
+        private_constant :MESSAGE_OPTIONS
 
-      included do
-        attr_reader :details
+        included do
+          attr_reader :details
 
-        %w[initialize initialize_dup add clear delete].each do |method|
-          alias_method_chain method, :details
+          %w[initialize initialize_dup add clear delete].each do |method|
+            alias_method_chain method, :details
+          end
+        end
+
+        def initialize_with_details(base)
+          @details = Hash.new { |details, attribute| details[attribute] = [] }
+          initialize_without_details(base)
+        end
+
+        def initialize_dup_with_details(other)
+          @details = other.details.deep_dup
+          initialize_dup_without_details(other)
+        end
+
+        def add_with_details(attribute, message = :invalid, options = {})
+          message = message.call if message.respond_to?(:call)
+
+          error = options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
+            .merge(error: message)
+          details[attribute].push(error)
+          add_without_details(attribute, message, options)
+        end
+
+        def clear_with_details
+          details.clear
+          clear_without_details
+        end
+
+        def delete_with_details(attribute)
+          details.delete(attribute)
+          delete_without_details(attribute)
         end
       end
-
-      def initialize_with_details(base)
-        @details = Hash.new { |details, attribute| details[attribute] = [] }
-        initialize_without_details(base)
-      end
-
-      def initialize_dup_with_details(other)
-        @details = other.details.deep_dup
-        initialize_dup_without_details(other)
-      end
-
-      def add_with_details(attribute, message = :invalid, options = {})
-        message = message.call if message.respond_to?(:call)
-
-        error = options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
-          .merge(error: message)
-        details[attribute].push(error)
-        add_without_details(attribute, message, options)
-      end
-
-      def clear_with_details
-        details.clear
-        clear_without_details
-      end
-
-      def delete_with_details(attribute)
-        details.delete(attribute)
-        delete_without_details(attribute)
-      end
+      include Details
     end
-    include Details unless method_defined?(:details)
   end
 end

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -151,9 +151,10 @@ module ActiveInteraction
       if attribute?(attribute) || attribute == :base
         options = detail.dup
         error = options.delete(:error)
-        options[:message] = message
 
-        add(attribute, error, options) unless added?(attribute, error, options)
+        unless added?(attribute, error, options)
+          add(attribute, error, options.merge(message: message))
+        end
       else
         merge_message!(attribute, message)
       end

--- a/spec/active_interaction/errors_spec.rb
+++ b/spec/active_interaction/errors_spec.rb
@@ -189,7 +189,7 @@ describe ActiveInteraction::Errors do
 
         it 'merges the nested errors' do
           a.valid?
-          expect(a.errors.messages).to eql(:'b.name' => ["can't be blank"])
+          expect(a.errors.messages).to eq(:'b.name' => ["can't be blank"])
           expect(a.errors.size).to eql 1
           expect { errors.merge!(a.errors) }.to_not raise_error
           expect(errors.size).to eql 1


### PR DESCRIPTION
* only includes Backports error details code when using ActiveModel < 5
* fixes spec to adhere to Rails 6.1

Closes #488 #489 #490 