### PR TITLE
Replace string passed to :unless with proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ class Example < ActiveInteraction::Base
 
   validates :first_name,
     presence: true,
-    unless: 'first_name.nil?'
+    unless: -> { first_name.nil? }
 
   def execute
     # ...

--- a/README.md
+++ b/README.md
@@ -977,10 +977,10 @@ class UpdateAccount < ActiveInteraction::Base
 
   validates :first_name,
     presence: true,
-    unless: 'first_name.nil?'
+    unless: -> { first_name.nil? }
   validates :last_name,
     presence: true,
-    unless: 'last_name.nil?'
+    unless: -> { last_name.nil? }
 
   def execute
     account.first_name = first_name if first_name.present?


### PR DESCRIPTION
In ActiveModel version 5.2 or later, passing a string to the if: and unless: options raises ArgumentError.
```
ArgumentError: Passing string to be evaluated in :if and :unless conditional options is not supported.
Pass a symbol for an instance method, or a lambda, proc or block, instead.
```
https://github.com/rails/rails/blob/main/activesupport/lib/active_support/callbacks.rb#L356

This PR replaces string passed to :unless option of validate methods in README with proc.
Could you please have a moment to take a look at it? @AaronLasseigne 