### PR TITLE
Strict Inputs: require provided inputs to explicitly match declared filters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
 Metrics/ClassLength:
-  Max: 120
+  Max: 130
 Metrics/MethodLength:
   Max: 15
 Style/FrozenStringLiteralComment:

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -79,6 +79,26 @@ module ActiveInteraction
         @_interaction_desc
       end
 
+      # Enables strict inputs.
+      #
+      # Requires that provided inputs to the interactor explicitly match declared filters.
+      #
+      # @example
+      #   strict_filters true
+      #
+      # @param strict [Boolean, nil] Enable strict inputs.
+      #
+      # @return [Boolean] Current strict input setting.
+      def strict_inputs(strict = nil)
+        if strict.nil?
+          @_interactor_strict_inputs = false unless instance_variable_defined?(:@_interactor_strict_inputs)
+        else
+          @_interactor_strict_inputs = strict
+        end
+
+        @_interactor_strict_inputs
+      end
+
       # Get all the filters defined on this interaction.
       #
       # @return [Hash{Symbol => Filter}]
@@ -288,7 +308,15 @@ module ActiveInteraction
         public_send("#{name}=", value)
       end
 
+      strict_inputs_check(inputs)
       @_interaction_inputs.freeze
+    end
+
+    def strict_inputs_check(inputs)
+      return unless self.class.strict_inputs
+      return unless (unexpected_keys = inputs.keys - @_interaction_inputs.keys).any?
+
+      raise InvalidInputsError, "unexpected inputs: #{unexpected_keys.join(', ')}."
     end
 
     def type_check

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -26,6 +26,11 @@ module ActiveInteraction
   # @return [Class]
   InvalidFilterError = Class.new(Error)
 
+  # Raised if a supplied inputs contain unexpected inputs.
+  #
+  # @return [Class]
+  InvalidInputsError = Class.new(Error)
+
   # Raised if an interaction is invalid.
   #
   # @return [Class]

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -127,6 +127,60 @@ describe ActiveInteraction::Base do
     end
   end
 
+  describe '.strict_inputs' do
+    let(:described_class) do
+      Class.new(TestInteraction) do
+        strict_inputs true
+        float :thing1
+        float :thing2, default: 12.34
+      end
+    end
+
+    context '#run' do
+      it 'accepts declared inputs' do
+        inputs[:thing1] = 1.0
+        inputs[:thing2] = 2.0
+
+        expect(outcome).to be_valid
+      end
+
+      it 'accepts declared inputs' do
+        inputs[:thing1] = 1.0
+
+        expect(outcome).to be_valid
+      end
+
+      it 'does not accept inputs for undeclared filters' do
+        inputs[:thing1] = 1.0
+        inputs[:thing2] = 2.0
+        inputs[:thing3] = 3.0
+
+        expect { outcome }.to raise_error ActiveInteraction::InvalidInputsError
+      end
+
+      it 'does not accept inputs for undeclared filters' do
+        inputs[:thing3] = 3.0
+
+        expect { outcome }.to raise_error ActiveInteraction::InvalidInputsError
+      end
+    end
+
+    context '#new' do
+      it 'accepts declared inputs' do
+        inputs[:thing1] = 1.0
+        inputs[:thing2] = 2.0
+
+        expect(described_class.new(inputs)).to be_valid
+      end
+
+      it 'does not accept inputs for undeclared filters' do
+        inputs[:thing3] = 3.0
+
+        expect { described_class.new(inputs) }.to raise_error ActiveInteraction::InvalidInputsError
+      end
+    end
+  end
+
   describe '.method_missing(filter_type, *args, &block)' do
     it 'raises an error for an invalid filter type' do
       expect do


### PR DESCRIPTION
Add the ability for interactors to be declared to only accept inputs that explicitly match declared filters so that not superfluous inputs are provided.

The desire for this cropped up recently in a larger project undergoing refactoring where unexpected inputs to interactors could be easily identified.