### PR TITLE
TEST: Fix error "undefined method `silence_warnings'"

### DIFF
--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'action_controller'
+require 'active_support/core_ext/kernel/reporting'
 
 InteractionWithFilter = Class.new(TestInteraction) do
   float :thing


### PR DESCRIPTION
Hi! I planned to contribute but I got error running the tests out of the box.
This PR fix errors I had:
```
rspec ./spec/active_interaction/base_spec.rb:224 # ActiveInteraction::Base with a filter .run(inputs = {}) passing validations failing runtime validations returns an invalid outcome
rspec ./spec/active_interaction/base_spec.rb:232 # ActiveInteraction::Base with a filter .run(inputs = {}) passing validations failing runtime validations has errors
rspec ./spec/active_interaction/base_spec.rb:239 # ActiveInteraction::Base with a filter .run(inputs = {}) passing validations failing runtime validations has detailed errors
rspec ./spec/active_interaction/base_spec.rb:228 # ActiveInteraction::Base with a filter .run(inputs = {}) passing validations failing runtime validations sets the result
```

My environment:
```
Ubuntu 22.04 LTS

Gems included by the bundle:
  * actionpack (7.0.3)
  * actionview (7.0.3)
  * active_interaction (4.1.0)
  * activemodel (7.0.3)
  * activerecord (7.0.3)
  * activesupport (7.0.3)
  * ast (2.4.2)
  * benchmark-ips (2.10.0)
  * builder (3.2.4)
  * bundler (2.3.14)
  * concurrent-ruby (1.1.10)
  * crass (1.0.6)
  * diff-lcs (1.5.0)
  * erubi (1.10.0)
  * i18n (1.10.0)
  * kramdown (2.4.0)
  * loofah (2.18.0)
  * minitest (5.15.0)
  * nokogiri (1.13.6)
  * parallel (1.22.1)
  * parser (3.1.2.0)
  * racc (1.6.0)
  * rack (2.2.3)
  * rack-test (1.1.0)
  * rails-dom-testing (2.0.3)
  * rails-html-sanitizer (1.4.2)
  * rainbow (3.1.1)
  * rake (13.0.6)
  * regexp_parser (2.4.0)
  * rexml (3.2.5)
  * rspec (3.11.0)
  * rspec-core (3.11.0)
  * rspec-expectations (3.11.0)
  * rspec-mocks (3.11.1)
  * rspec-support (3.11.0)
  * rubocop (1.24.1)
  * rubocop-ast (1.18.0)
  * rubocop-rake (0.6.0)
  * rubocop-rspec (2.7.0)
  * ruby-progressbar (1.11.0)
  * sqlite3 (1.4.2)
  * tzinfo (2.0.4)
  * unicode-display_width (2.1.0)
  * webrick (1.7.0)
  * yard (0.9.27)
```