### PR TITLE
Fix compose inputs

### DIFF
--- a/lib/active_interaction/inputs.rb
+++ b/lib/active_interaction/inputs.rb
@@ -87,7 +87,6 @@ module ActiveInteraction
       :size,
       :slice,
       :store,
-      :stringify_keys,
       :to_a,
       :to_s,
       :value?,
@@ -176,7 +175,8 @@ module ActiveInteraction
     end
 
     def convert(inputs)
-      return inputs.stringify_keys if inputs.is_a?(Hash) || inputs.is_a?(Inputs)
+      return inputs if inputs.is_a?(self.class)
+      return inputs.stringify_keys if inputs.is_a?(Hash)
       return inputs.to_unsafe_h.stringify_keys if inputs.is_a?(ActionController::Parameters)
 
       raise ArgumentError, 'inputs must be a hash or ActionController::Parameters'

--- a/lib/active_interaction/inputs.rb
+++ b/lib/active_interaction/inputs.rb
@@ -87,6 +87,7 @@ module ActiveInteraction
       :size,
       :slice,
       :store,
+      :stringify_keys,
       :to_a,
       :to_s,
       :value?,
@@ -175,7 +176,7 @@ module ActiveInteraction
     end
 
     def convert(inputs)
-      return inputs.stringify_keys if inputs.is_a?(Hash)
+      return inputs.stringify_keys if inputs.is_a?(Hash) || inputs.is_a?(Inputs)
       return inputs.to_unsafe_h.stringify_keys if inputs.is_a?(ActionController::Parameters)
 
       raise ArgumentError, 'inputs must be a hash or ActionController::Parameters'

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -294,17 +294,28 @@ describe ActiveInteraction::Base do
     let(:z) { rand }
 
     context 'with valid composition' do
-      before do
-        inputs[:x] = x
-        inputs[:z] = z
+      context 'when inputs is a hash' do
+        let(:inputs) { { x: x, z: z } }
+
+        it 'is valid' do
+          expect(outcome).to be_valid
+        end
+
+        it 'returns the sum' do
+          expect(result).to eql x + z
+        end
       end
 
-      it 'is valid' do
-        expect(outcome).to be_valid
-      end
+      context 'when inputs is an ActiveInteraction::Inputs' do
+        let(:inputs) { ActiveInteraction::Inputs.new({ x: x, z: z }, described_class.new) }
 
-      it 'returns the sum' do
-        expect(result).to eql x + z
+        it 'is valid' do
+          expect(outcome).to be_valid
+        end
+
+        it 'returns the sum' do
+          expect(result).to eql x + z
+        end
       end
     end
 

--- a/spec/active_interaction/inputs_spec.rb
+++ b/spec/active_interaction/inputs_spec.rb
@@ -44,6 +44,14 @@ describe ActiveInteraction::Inputs do
       end
     end
 
+    context 'with ActiveInteraction::Inputs inputs' do
+      let(:args) { described_class.new({ key: :value }, base_class.new) }
+
+      it 'does not raise an error' do
+        expect { result }.to_not raise_error
+      end
+    end
+
     context 'with ActionController::Parameters inputs' do
       let(:args) { ::ActionController::Parameters.new }
 


### PR DESCRIPTION
While upgrading to active interaction `5.0.0` I found that the `inputs must be a hash or ActionController::Parameters` argument error is being raised when inputs are composed within an interaction (i.e. `compose(Multiply, inputs)` ). It looks like that error will be raised unless they are a hash or an `ActionController::Parameters` instance when we probably want to also allow them to be `Inputs` for composition. 

I wrote two test cases, one for the `#normalized` method where the error gets raised to make sure it does not when they are of type `ActiveInteraction::Inputs` and one for the `#compose` method directly to ensure it is a valid outcome for both a hash or an `Inputs` instance.

It's my first time reading through the library source, so if I'm missing anything obvious or there is a better way to approach this let me know how I can help!