### PR TITLE
Use a non-destructive `map` call when transforming an Array filter

### DIFF
--- a/lib/active_interaction/filters/array_filter.rb
+++ b/lib/active_interaction/filters/array_filter.rb
@@ -49,7 +49,7 @@ module ActiveInteraction
       children = []
 
       unless filters.empty?
-        value.map! do |item|
+        value = value.map do |item|
           result = filters[:'0'].process(item, context)
           children.push(result)
           result.value

--- a/spec/active_interaction/filters/array_filter_spec.rb
+++ b/spec/active_interaction/filters/array_filter_spec.rb
@@ -74,6 +74,11 @@ describe ActiveInteraction::ArrayFilter, :filter do
       it 'returns the transformed value' do
         expect(result.value).to eql [:test]
       end
+
+      it 'does not modify the original value' do
+        expect(result.value.object_id).to_not eql value.object_id
+        expect(value).to eql ['test']
+      end
     end
 
     context 'with a nested filter' do


### PR DESCRIPTION
Addresses #545 

Description has most of the detail: simply replace the `map!` call in `ArrayFilter#process` to reassign and use `map`.

I only added a test for the `ArrayFilter` class but happy to add a more comprehensive integration test.

Happy for any feedback!