### PR TITLE
Add composable method for using compose like dsl

### DIFF
--- a/lib/active_interaction.rb
+++ b/lib/active_interaction.rb
@@ -19,6 +19,7 @@ require_relative 'active_interaction/concerns/active_recordable'
 require_relative 'active_interaction/concerns/hashable'
 require_relative 'active_interaction/concerns/missable'
 require_relative 'active_interaction/concerns/runnable'
+require_relative 'active_interaction/concerns/sugarable'
 
 require_relative 'active_interaction/grouped_input'
 require_relative 'active_interaction/input'

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -35,6 +35,7 @@ module ActiveInteraction
     class << self
       include Hashable
       include Missable
+      include Sugarable
 
       # @!method run(inputs = {})
       #   @note If the interaction inputs are valid and there are no runtime

--- a/lib/active_interaction/concerns/sugarable.rb
+++ b/lib/active_interaction/concerns/sugarable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveInteraction
+  module Sugarable
+    def composable(interaction, params = [], method: nil)
+      method_name = method || interaction.to_s.gsub('::', '').underscore
+
+      define_method method_name do
+        compose(interaction, params.to_h { |p| [p, public_send(p)] })
+      end
+    end
+  end
+end

--- a/spec/active_interaction/concerns/sugarable_spec.rb
+++ b/spec/active_interaction/concerns/sugarable_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe ActiveInteraction::Sugarable do
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  InnerInteraction = Class.new(TestInteraction) do
+    integer :x
+    integer :y
+
+    def execute
+      x + y
+    end
+  end
+
+  describe '#composable' do
+    subject { OuterInteraction.run!(x: 5, y: 20) }
+
+    context 'with default method name for inner interaction' do
+      OuterInteraction = Class.new(TestInteraction) do
+        integer :x
+        integer :y
+
+        composable(InnerInteraction, %i[x y])
+
+        def execute
+          inner_interaction
+        end
+      end
+
+      it { is_expected.to eq(25) }
+    end
+
+    context 'with custom method name for inner interaction' do
+      OuterInteraction = Class.new(TestInteraction) do
+        integer :x
+        integer :y
+
+        composable(InnerInteraction, %i[x y], method: 'custom_interaction')
+
+        def execute
+          custom_interaction
+        end
+      end
+
+      it { is_expected.to eq(25) }
+    end
+
+    context 'with inner interaction with namespace' do
+      module CustomNamespace
+        class InnerInteraction < TestInteraction
+          integer :x
+          integer :y
+
+          def execute
+            x + y
+          end
+        end
+      end
+
+      OuterInteraction = Class.new(TestInteraction) do
+        integer :x
+        integer :y
+
+        composable(CustomNamespace::InnerInteraction, %i[x y])
+
+        def execute
+          custom_namespace_inner_interaction
+        end
+      end
+
+      it { is_expected.to eq(25) }
+    end
+
+    context 'with passing data from method' do
+      OuterInteraction = Class.new(TestInteraction) do
+        integer :x
+
+        composable(InnerInteraction, %i[x y])
+
+        def execute
+          inner_interaction
+        end
+
+        def y
+          20
+        end
+      end
+
+      it { is_expected.to eq(25) }
+    end
+  end
+  # rubocop:enable Lint/ConstantDefinitionInBlock
+end


### PR DESCRIPTION
This code add method _composable_. 
It must be rewrited. It created for showing main idea.
Sometimes when you have many composable interactors inside main interactor you want push args by name
```
class SomeInteractor
   integer :a
   integer :b
   string :c
   string :d
  
  composable(ChildInteractor1, %i[a b])
  composable(ChildInteractor2, %[b c], method: 'custom_child_interactor')
  composable(SomeNamespace::ChildInteractor3, %[c d])
  composable(ChildInteractor4, %i[a b c d current_user])  

  def execute
     child_interactor1
     custom_child_interactor
     some_namespace_child_interactor3
  end

  def current_user
    #SomeCode
  end
```

It makes execute method clear