### PR TITLE
fix: full messages correct map

### DIFF
--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -17,7 +17,7 @@ module ActiveInteraction
     end
 
     def full_messages
-      map(&:message)
+      map(&:full_message)
     end
 
     # @private

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -16,6 +16,10 @@ module ActiveInteraction
       self
     end
 
+    def full_messages
+      map(&:message)
+    end
+
     # @private
     def local_attribute(attribute)
       attribute.to_s.sub(/\A([^.\[]*).*\z/, '\1').to_sym


### PR DESCRIPTION
Link for issue
https://github.com/AaronLasseigne/active_interaction/issues/556
I found that it is possible to do map full_message in the right class and this will fix the problem