### PR TITLE
Add JRuby 9.4 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,13 @@ jobs:
     name: Test Ruby ${{ matrix.ruby }} on ActiveModel ${{ matrix.activemodel }}
     strategy:
       matrix:
-        ruby: ["3.2"]
+        ruby: ["3.2", "jruby-9.4"]
         activemodel: ["7.0"]
         include:
           - activemodel: "6.1"
             ruby: "3.1"
+          - activemodel: "6.1"
+            ruby: "jruby-9.4"
           - activemodel: "6.0"
             ruby: "3.0"
           - activemodel: "5.2"

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -4,4 +4,11 @@ gemspec path: '..'
 
 gem 'activemodel', '~> 5.2.0'
 gem 'activerecord', '~> 5.2.0'
-gem 'sqlite3', '~> 1.3.13'
+
+platforms :mri do
+  gem 'sqlite3', '~> 1.3.13'
+end
+platforms :jruby do
+  gem 'activerecord-jdbc-adapter', '~> 52'
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 52'
+end

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -4,4 +4,11 @@ gemspec path: '..'
 
 gem 'activemodel', '~> 6.0.0'
 gem 'activerecord', '~> 6.0.0'
-gem 'sqlite3', '~> 1.4.1'
+
+platforms :mri do
+  gem 'sqlite3', '~> 1.4.1'
+end
+platforms :jruby do
+  gem 'activerecord-jdbc-adapter', '~> 60'
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 60'
+end

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -4,4 +4,11 @@ gemspec path: '..'
 
 gem 'activemodel', '~> 6.1.0'
 gem 'activerecord', '~> 6.1.0'
-gem 'sqlite3', '~> 1.4.1'
+
+platforms :mri do
+  gem 'sqlite3', '~> 1.4.1'
+end
+platforms :jruby do
+  gem 'activerecord-jdbc-adapter', '~> 61'
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 61'
+end

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -4,4 +4,11 @@ gemspec path: '..'
 
 gem 'activemodel', '~> 7.0.1'
 gem 'activerecord', '~> 7.0.1'
-gem 'sqlite3', '~> 1.4.1'
+
+platforms :mri do
+  gem 'sqlite3', '~> 1.4.1'
+end
+platforms :jruby do
+  gem 'activerecord-jdbc-adapter', '~> 70'
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 70'
+end

--- a/spec/active_interaction/errors_spec.rb
+++ b/spec/active_interaction/errors_spec.rb
@@ -1,5 +1,9 @@
 require 'active_record'
-require 'sqlite3'
+if defined? JRUBY_VERSION
+  require 'activerecord-jdbc-adapter'
+else
+  require 'sqlite3'
+end
 
 ActiveRecord::Base.establish_connection(
   adapter: 'sqlite3',

--- a/spec/active_interaction/integration/array_interaction_spec.rb
+++ b/spec/active_interaction/integration/array_interaction_spec.rb
@@ -1,5 +1,9 @@
 require 'active_record'
-require 'sqlite3'
+if defined? JRUBY_VERSION
+  require 'activerecord-jdbc-adapter'
+else
+  require 'sqlite3'
+end
 
 ActiveRecord::Base.establish_connection(
   adapter: 'sqlite3',


### PR DESCRIPTION
I noticed that JRuby was [dropped](https://github.com/AaronLasseigne/active_interaction/blob/70da43173e29b44f0ade027140aae1cbd721f66a/CHANGELOG.md#changed) at 5.0 due to the syntax being out of date, now that JRuby 9.4 is bringing 3.1 syntax I feel this would be a good time to reintroduce it.