### PR TITLE
Add `<kind>_<action>` method to handle callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,24 +1053,34 @@ interaction's lifecycle.
 
 ``` rb
 class Increment < ActiveInteraction::Base
-  set_callback :filter, :before, -> { puts 'before filter' }
+  before_validate do
+    puts 'before validate'
+  end
+  # or you can use the `set_callback` method
+  # set_callback :validate, :before, -> { puts 'before validate' }
 
   integer :x
 
-  set_callback :validate, :after, -> { puts 'after validate' }
+  after_validate :echo_after_validate
 
   validates :x,
     numericality: { greater_than_or_equal_to: 0 }
 
-  set_callback :execute, :around, lambda { |_interaction, block|
+  around_execute do |_interaction, block|
     puts '>>>'
     block.call
     puts '<<<'
-  }
+  end
 
   def execute
     puts 'executing'
     x + 1
+  end
+
+  private
+
+  def echo_after_validate
+    puts 'after validate'
   end
 end
 
@@ -1082,6 +1092,8 @@ Increment.run!(x: 1)
 # <<<
 # => 2
 ```
+
+Of course, you can set callback using `set_callback` manually.
 
 In order, the available callbacks are `filter`, `validate`, and `execute`.
 You can set `before`, `after`, or `around` on any of them.

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -88,6 +88,36 @@ module ActiveInteraction
         # rubocop:enable Naming/MemoizedInstanceVariableName
       end
 
+      # Set a callback that will be run before {#filter}.
+      def before_filter(*args, &block)
+        set_callback(:filter, :before, *args, &block)
+      end
+
+      # Set a callback that will be run after {#filter}.
+      def after_filter(*args, &block)
+        set_callback(:filter, :after, *args, &block)
+      end
+
+      # Set a callback that will be run around {#filter}.
+      def around_filter(*args, &block)
+        set_callback(:filter, :around, *args, &block)
+      end
+
+      # Set a callback that will be run before {#validate}.
+      def before_validate(*args, &block)
+        set_callback(:validate, :before, *args, &block)
+      end
+
+      # Set a callback that will be run after {#validate}.
+      def after_validate(*args, &block)
+        set_callback(:validate, :after, *args, &block)
+      end
+
+      # Set a callback that will be run around {#validate}.
+      def around_validate(*args, &block)
+        set_callback(:validate, :around, *args, &block)
+      end
+
       private
 
       # rubocop:disable Style/MissingRespondToMissing

--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -120,6 +120,21 @@ module ActiveInteraction
       def run!(*args)
         new(*args).send(:run!)
       end
+
+      # Set a callback that will be run before {#execute}.
+      def before_execute(*args, &block)
+        set_callback(:execute, :before, *args, &block)
+      end
+
+      # Set a callback that will be run after {#execute}.
+      def after_execute(*args, &block)
+        set_callback(:execute, :after, *args, &block)
+      end
+
+      # Set a callback that will be run around {#execute}.
+      def around_execute(*args, &block)
+        set_callback(:execute, :around, *args, &block)
+      end
     end
   end
 end


### PR DESCRIPTION
I think 

```ruby
before_execute :some_callback
```

is much more nice API than below.

```ruby
set_callback :execute, :before, :some_callback
```

So, I add helper method to provide similar interface in `ActiveRecord` like `after_commit`, `before_validation`.

