### PR TITLE
Test active_interaction on ruby 3.3 and rails 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -23,9 +23,11 @@ jobs:
     name: Test Ruby ${{ matrix.ruby }} on ActiveModel ${{ matrix.activemodel }}
     strategy:
       matrix:
-        ruby: ["3.2"]
-        activemodel: ["7.0"]
+        ruby: ["3.2", "3.3"]
+        activemodel: ["7.1"]
         include:
+          - activemodel: "7.0"
+            ruby: "3.2"
           - activemodel: "6.1"
             ruby: "3.1"
           - activemodel: "6.0"
@@ -38,7 +40,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails-${{ matrix.activemodel }}.gemfile
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Prerequisites
       run: sudo apt install libsqlite3-dev

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activemodel', '~> 7.1.0'
+gem 'activerecord', '~> 7.1.0'
+gem 'sqlite3', '~> 1.7.3'


### PR DESCRIPTION
I added Ruby 3.3 and Rails 7.1 for testing.

Ruby 3.3.0 has a few regressions so I still keep ruby 3.2 in the matrix in the CI.