### PR TITLE
fix unexpected behavior around filters with validators

### DIFF
--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -205,6 +205,7 @@ module ActiveInteraction
       filter
 
       super if errors.empty?
+      errors.empty?
     end
 
     private

--- a/lib/active_interaction/modules/validation.rb
+++ b/lib/active_interaction/modules/validation.rb
@@ -8,10 +8,10 @@ module ActiveInteraction
     class << self
       # @param context [Base]
       # @param filters [Hash{Symbol => Filter}]
-      # @param inputs [Inputs]
-      def validate(context, filters, inputs)
+      # @param _inputs [Inputs]
+      def validate(context, filters, _inputs)
         filters.each_with_object([]) do |(name, filter), errors|
-          input = filter.process(inputs[name], context)
+          input = filter.process(context.send(name), context)
 
           input.errors.each do |error|
             errors << [error.name, error.type, error.options]

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -5,6 +5,11 @@ InteractionWithFilter = Class.new(TestInteraction) do
   float :thing
 end
 
+InteractionWithFilterAndValidator = Class.new(TestInteraction) do
+  string :thing
+  validates :thing, presence: true
+end
+
 InteractionWithDateFilter = Class.new(TestInteraction) do
   date :thing
 end
@@ -103,6 +108,19 @@ RSpec.describe ActiveInteraction::Base do
 
         it 'returns a Date' do
           expect(interaction.thing).to eql Date.new(year, month, day)
+        end
+      end
+
+      context 'and a validator' do
+        let(:described_class) { InteractionWithFilterAndValidator }
+
+        it 'returns false on validation with no value given' do
+          expect(interaction.valid?).to be false
+        end
+
+        it 'passes validation when value is given later' do
+          interaction.thing = 'potato'
+          expect(interaction).to be_valid
         end
       end
     end

--- a/spec/active_interaction/modules/validation_spec.rb
+++ b/spec/active_interaction/modules/validation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ActiveInteraction::Validation do
     let(:filter) { ActiveInteraction::Filter.new(:name, {}) }
     let(:interaction) do
       name = filter.name
-      klass = Class.new(ActiveInteraction::Base) { attr_writer(name) }
+      klass = Class.new(ActiveInteraction::Base) { attr_accessor(name) }
       klass.filters[name] = filter
       klass.new
     end


### PR DESCRIPTION
Fixes https://github.com/AaronLasseigne/active_interaction/issues/574

In my first example from that issue, the problem is that in the overridden `run_validations!` method, it doesn't end by calling `errors.empty?` [the way that the Rails Validations class method does](https://github.com/rails/rails/blob/1e026dbf504547654eb03325448a7fffd575f923/activemodel/lib/active_model/validations.rb#L440-L443).
```ruby
def run_validations!
  _run_validate_callbacks
  errors.empty?
end
```

In my second example, the issue is that on initialization `@_interaction_inputs` is set based on the original values sent over.  Since nothing is being set, and there's no default value, it becomes `nil`.  However, as updates are made to the filter value, nothing ever updates that original mapping so it will always fail.  I went back and forth on how to address this, considering a callback to update the Input definition, but that didn't seem necessary when I had the actual context available.  I also considered removing the now-unused inputs param, but didn't want to force an API change on you.