### PR TITLE
fix unexpected behavior around filters with validators

### DIFF
--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -205,6 +205,7 @@ module ActiveInteraction
       filter
 
       super if errors.empty?
+      errors.empty?
     end
 
     private

--- a/lib/active_interaction/modules/validation.rb
+++ b/lib/active_interaction/modules/validation.rb
@@ -8,10 +8,10 @@ module ActiveInteraction
     class << self
       # @param context [Base]
       # @param filters [Hash{Symbol => Filter}]
-      # @param inputs [Inputs]
-      def validate(context, filters, inputs)
+      # @param _inputs [Inputs]
+      def validate(context, filters, _inputs)
         filters.each_with_object([]) do |(name, filter), errors|
-          input = filter.process(inputs[name], context)
+          input = filter.process(context.send(name), context)
 
           input.errors.each do |error|
             errors << [error.name, error.type, error.options]

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -5,6 +5,11 @@ InteractionWithFilter = Class.new(TestInteraction) do
   float :thing
 end
 
+InteractionWithFilterAndValidator = Class.new(TestInteraction) do
+  string :thing
+  validates :thing, presence: true
+end
+
 InteractionWithDateFilter = Class.new(TestInteraction) do
   date :thing
 end
@@ -103,6 +108,19 @@ RSpec.describe ActiveInteraction::Base do
 
         it 'returns a Date' do
           expect(interaction.thing).to eql Date.new(year, month, day)
+        end
+      end
+
+      context 'and a validator' do
+        let(:described_class) { InteractionWithFilterAndValidator }
+
+        it 'returns false on validation with no value given' do
+          expect(interaction.valid?).to be false
+        end
+
+        it 'passes validation when value is given later' do
+          interaction.thing = 'potato'
+          expect(interaction).to be_valid
         end
       end
     end

--- a/spec/active_interaction/validation_spec.rb
+++ b/spec/active_interaction/validation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ActiveInteraction::Validation do
     let(:filter) { ActiveInteraction::Filter.new(:name, {}) }
     let(:interaction) do
       name = filter.name
-      klass = Class.new(ActiveInteraction::Base) { attr_writer(name) }
+      klass = Class.new(ActiveInteraction::Base) { attr_accessor(name) }
       klass.filters[name] = filter
       klass.new
     end


### PR DESCRIPTION
Given the following interaction, I would expect behavior around validations to be:
```ruby
class Foo < ::ActiveInteractin::Base
  string :bar
  validates :bar, presence: true
end

x = Foo.new
x.valid? == false # it's actually nil
x.bar = "baz"
x.valid? == true # unfortunately it's still nil
```

In each test, rather than the boolean expected, I'm seeing `nil` returned.  In the first example, that's at least still falsey, but it's not the behavior I'd expect from a typical failed validation using vanilla ActiveModel validations.  In the second example that should cure the validation problem, but I still see `nil`.