### PR TITLE
Move `ostruct` dependency from development to runtime

### DIFF
--- a/active_interaction.gemspec
+++ b/active_interaction.gemspec
@@ -37,12 +37,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activemodel', '>= 5.2', '< 9'
   spec.add_dependency 'activesupport', '>= 5.2', '< 9'
+  spec.add_dependency 'ostruct', '~> 0.6'
 
   {
     'actionpack' => [],
     'activerecord' => [],
     'kramdown' => ['~> 2.1'],
-    'ostruct' => ['~> 0.6'],
     'rake' => ['~> 13.0'],
     'rspec' => ['~> 3.5'],
     'rubocop' => ['~> 1.68.0'],


### PR DESCRIPTION
```
/vendor/bundle/ruby/3.4.0/gems/active_interaction-5.4.0/lib/active_interaction/grouped_input.rb:3: warning:
ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```