### PR TITLE
Add :run callback support to interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,7 @@ interaction's lifecycle.
 
 ``` rb
 class Increment < ActiveInteraction::Base
+  set_callback :run, :before, -> { puts 'before run' }
   set_callback :filter, :before, -> { puts 'before filter' }
 
   integer :x
@@ -1075,6 +1076,7 @@ class Increment < ActiveInteraction::Base
 end
 
 Increment.run!(x: 1)
+# before run
 # before filter
 # after validate
 # >>>
@@ -1083,7 +1085,7 @@ Increment.run!(x: 1)
 # => 2
 ```
 
-In order, the available callbacks are `filter`, `validate`, and `execute`.
+In order, the available callbacks are `run`, `filter`, `validate`, and `execute`.
 You can set `before`, `after`, or `around` on any of them.
 
 ### Composition

--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -15,6 +15,7 @@ module ActiveInteraction
 
     included do
       define_callbacks :execute
+      define_callbacks :run
     end
 
     # @return [Errors]
@@ -69,13 +70,15 @@ module ActiveInteraction
     # @return (see #result=)
     # @return [nil]
     def run
-      return self.result = nil unless valid?
+      run_callbacks(:run) do
+        return self.result = nil unless valid?
 
-      self.result = run_callbacks(:execute) do
-        execute
-      rescue Interrupt => e
-        errors.backtrace = e.errors.backtrace || e.backtrace
-        errors.merge!(e.errors)
+        self.result = run_callbacks(:execute) do
+          execute
+        rescue Interrupt => e
+          errors.backtrace = e.errors.backtrace || e.backtrace
+          errors.merge!(e.errors)
+        end
       end
     end
 

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe ActiveInteraction::Base do
   context 'callbacks' do
     let(:described_class) { Class.new(TestInteraction) }
 
-    %w[filter validate execute].each do |name|
+    %w[run filter validate execute].each do |name|
       %w[before after around].map(&:to_sym).each do |type|
         it "runs the #{type} #{name} callback" do
           called = false
@@ -478,6 +478,33 @@ RSpec.describe ActiveInteraction::Base do
           expect(called).to be_truthy
         end
       end
+    end
+
+    it 'runs callbacks in the correct order' do
+      execution_log = []
+      described_class.set_callback(:filter, :before) { execution_log << :before_filter }
+      described_class.set_callback(:filter, :after) { execution_log << :after_filter }
+      described_class.set_callback(:validate, :before) { execution_log << :before_validate }
+      described_class.set_callback(:validate, :after) { execution_log << :after_validate }
+      described_class.set_callback(:execute, :before) { execution_log << :before_execute }
+      described_class.set_callback(:execute, :after) { execution_log << :after_execute }
+      described_class.set_callback(:run, :before) { execution_log << :before_run }
+      described_class.set_callback(:run, :after) { execution_log << :after_run }
+
+      outcome
+
+      expect(execution_log).to eq(
+        %i[
+          before_run
+          before_filter
+          after_filter
+          before_validate
+          after_validate
+          before_execute
+          after_execute
+          after_run
+        ]
+      )
     end
 
     context 'with errors during filter' do

--- a/spec/active_interaction/concerns/runnable_spec.rb
+++ b/spec/active_interaction/concerns/runnable_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe ActiveInteraction::Runnable do
 
       include_examples 'set_callback examples', :validate
       include_examples 'set_callback examples', :execute
+      include_examples 'set_callback examples', :run
 
       context 'execute with composed interaction' do
         class WithFailingCompose # rubocop:disable Lint/ConstantDefinitionInBlock


### PR DESCRIPTION
https://github.com/AaronLasseigne/active_interaction/issues/593

Problem:
In some services, I'd like to wrap the full operation in a mutex lock inside of the service itself.

In my case I am using RedLock to prevent race conditions. When I used it to wrap the contents of my `execute` block, some values were actually being cached prior during the ActiveInteraction validations - at the same time, another thread was still running its `execute` block with the mutex lock. The first thread releases the lock and the second thread begins its `execute` block, acquiring a lock for itself, but having already cached some values that are then out of date. The currently available set_callback functionality allows for callbacks around `filter`, `validate`, and `execute`, but you cannot wrap all of those in one action. I would prefer to use the block implementation from Redlock rather than worrying about starting a lock and then ensuring it is released in all scenarios.

Ideally, I'd like to do something like this:
```
set_callback :run, :around, lambda { |_interaction, block|
    lock_manager = Redlock::Client.new(MY_REDIS_CONFIG)
    lock_manager.lock!("resource_key", 2000) do
      block.call
    end
  }
```

Approach:
Here is a breakdown of what was added:
- Added define_callbacks :run to Runnable module
- Wrapped #run method with run_callbacks to allow :before, :after, and :around callbacks
- Added tests for :run callback with all three types
- Updated README with documentation and example

I got this running locally and have ran `rake` locally to confirm that all tests and linting pass.

--- 
I'd be grateful if maintainers would consider this addition as a small, but helpful addition when wanting to wrap the entire execution from within the ActiveInteraction service without having to do something like overwrite the `run!` method from within. Thanks for your consideration!