### PR TITLE
Rescue TypeError in date/time and numeric filter converters

### DIFF
--- a/lib/active_interaction/filters/abstract_date_time_filter.rb
+++ b/lib/active_interaction/filters/abstract_date_time_filter.rb
@@ -51,7 +51,7 @@ module ActiveInteraction
       else
         klass.parse(value) || value
       end
-    rescue ArgumentError
+    rescue ArgumentError, TypeError
       value
     end
 

--- a/lib/active_interaction/filters/abstract_numeric_filter.rb
+++ b/lib/active_interaction/filters/abstract_numeric_filter.rb
@@ -44,7 +44,7 @@ module ActiveInteraction
 
     def safe_converter(value)
       converter(value)
-    rescue ArgumentError
+    rescue ArgumentError, TypeError
       value
     end
   end

--- a/spec/active_interaction/filters/date_filter_spec.rb
+++ b/spec/active_interaction/filters/date_filter_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe ActiveInteraction::DateFilter, :filter do
       end
     end
 
+    context 'with a #to_str that returns a non-String' do
+      let(:value) do
+        Class.new do
+          def to_str
+            :not_a_string
+          end
+        end.new
+      end
+
+      it 'returns a filter error instead of raising TypeError' do
+        expect { result }.not_to raise_error
+        expect(result.errors.first).to be_an_instance_of ActiveInteraction::Filter::Error
+        expect(result.errors.first.type).to be :invalid_type
+      end
+    end
+
     context 'with a blank String' do
       let(:value) do
         Class.new do

--- a/spec/active_interaction/filters/integer_filter_spec.rb
+++ b/spec/active_interaction/filters/integer_filter_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe ActiveInteraction::IntegerFilter, :filter do
       end
     end
 
+    context 'with a #to_str that returns a non-String' do
+      let(:value) do
+        Class.new do
+          def to_str
+            :not_a_string
+          end
+        end.new
+      end
+
+      it 'returns a filter error instead of raising TypeError' do
+        expect { result }.not_to raise_error
+        expect(result.errors.first).to be_an_instance_of ActiveInteraction::Filter::Error
+        expect(result.errors.first.type).to be :invalid_type
+      end
+    end
+
     context 'with a blank String' do
       let(:value) do
         Class.new do


### PR DESCRIPTION
## Problem

`AbstractDateTimeFilter#convert_string` and `AbstractNumericFilter#safe_converter` only rescue `ArgumentError`. When an input object has `to_str` / `to_int` that returns a non-String / non-Integer (legal Ruby, though it violates the implicit-conversion contract), the underlying parse raises `TypeError`, which escapes the filter and propagates out of `.run` as an unhandled exception:

```ruby
class DateCheck < ActiveInteraction::Base
  date :d
  def execute; d; end
end

class BadStr
  def to_str; :not_a_string; end
  def respond_to?(m, *); m == :to_str || super; end
end

DateCheck.run(d: BadStr.new)
# => TypeError: no implicit conversion of Symbol into String
```

This breaks the contract that `.run` returns a result — even for bad input, it should surface a validation error, not raise. The same pattern exists in `AbstractNumericFilter#safe_converter` where `Integer(non_int)` / `Float(non_str)` / `BigDecimal(non_str)` raise `TypeError` that isn't caught.

## Fix

Rescue `TypeError` alongside `ArgumentError` in both filters, so non-conforming `to_str` / `to_int` values surface as `:invalid_type` filter errors — consistent with how unparseable strings are already handled.

## Test plan

- [x] Added specs in `date_filter_spec.rb` and `integer_filter_spec.rb` that construct values with a `to_str` returning a Symbol. Both specs **fail on `main` with uncaught `TypeError`** and pass with this change.
- [x] Full `bundle exec rspec` suite passes (1088 examples, 0 failures).
- [x] The two new specs were verified to fail against unpatched code before restoring the fix.

Marking draft while maintainers review the approach.
